### PR TITLE
Update links for legacy source links

### DIFF
--- a/helpers/application_helpers.rb
+++ b/helpers/application_helpers.rb
@@ -1,6 +1,11 @@
 module ApplicationHelpers
   def github_file_url(file_path, version)
-    "https://github.com/thoughtbot/neat/blob/v#{version}/core/#{file_path}"
+    major_version = version.to_s.split(".").first
+    if major_version == "1"
+      "https://github.com/thoughtbot/neat/blob/v#{version}/app/assets/stylesheets/#{file_path}"
+    else
+      "https://github.com/thoughtbot/neat/blob/v#{version}/core/#{file_path}"
+    end
   end
 
   def markdown(contents)


### PR DESCRIPTION
since we changed the asset library location from `app/asset/stylesheets/` to `core` in 2.0, we need to check the links out.

I used `if version.to_s[0] == "1"` but there may be a better way to do it.