### PR TITLE
Add handling for undefined group names in legacy docs

### DIFF
--- a/source/docs/version/index.html.slim
+++ b/source/docs/version/index.html.slim
@@ -20,9 +20,10 @@
             code
               = version
     - version.doc_items.group_by {|a| a.group }.reverse_each do |group, items|
-      h2.docs-nav__heading
-        = link_to group.join.titleize, "##{group.join.slugify}",
-          class: "docs-nav__link"
+      - if group.join != "undefined"
+        h2.docs-nav__heading
+          = link_to group.join.titleize, "##{group.join.slugify}",
+            class: "docs-nav__link"
       ol.docs-nav__list
         - items.each do |item|
           li.docs-nav__item
@@ -33,8 +34,9 @@
   section.docs-list
     - version.doc_items.group_by {|a| a.group }.reverse_each do |group, items|
       .docs-section
-        h2 id="#{group.join.slugify}"
-          = group.join.titleize
+        - if group.join != "undefined"
+          h2 id="#{group.join.slugify}"
+            = group.join.titleize
         - items.each do |item|
           article.doc-item id="#{item.context.name.slugify}"
             .doc-item__section


### PR DESCRIPTION
Because they predate the use of sassdoc for documentation, older versions of
neat (`~>'1.8'`) do not have groups defined for the various features. This
caused the group names to read as "Undefined". This change checks to see if
they are undefined and if it is, the group heading will be omitted.

https://github.com/thoughtbot/neat/issues/564

## Old

<img width="1040" alt="screen shot 2017-03-17 at 2 56 23 pm" src="https://cloud.githubusercontent.com/assets/2489247/24058575/f39b53bc-0b21-11e7-8757-35b43546dd21.png">

## New

<img width="1094" alt="screen shot 2017-03-17 at 2 56 15 pm" src="https://cloud.githubusercontent.com/assets/2489247/24058587/fa955f00-0b21-11e7-8c2b-2f04845bd571.png">

