### PR TITLE
Fix scrollbar visual glitch on Firefox

### DIFF
--- a/source/assets/stylesheets/components/_docs-nav.scss
+++ b/source/assets/stylesheets/components/_docs-nav.scss
@@ -11,7 +11,7 @@
       position: fixed;
       top: 0;
       max-height: 100vh;
-      overflow: -moz-scrollbars-none;
+      overflow: hidden;
       overflow-y: scroll;
       overflow-x: visible;
 


### PR DESCRIPTION
`-moz-scrollbars-none` is obsolete and causing visual glitch on Firefox
https://developer.mozilla.org/en-US/docs/Web/CSS/overflow#Mozilla_Extensions

see : 
![screenshot from 2017-03-24 15-52-52](https://cloud.githubusercontent.com/assets/2945291/24299742/72d4de04-10aa-11e7-9dc6-9ac5d8fbe7c7.png)

Tested on Firefox 53.0 / Linux 